### PR TITLE
fix: add random string suffixes

### DIFF
--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -1,7 +1,14 @@
+resource "random_string" "this" {
+  length  = 5
+  special = false
+  numeric = false
+  upper   = false
+}
+
 locals {
-  # need to parse the date because bucket names do not accept ":"
-  bucket_name_def          = var.bucket_name == null ? "${var.project_id}-atlas-push-log-${formatdate("YY-M-D-h-m-s", timestamp())}" : var.bucket_name
-  iam_role_name_def        = var.iam_role_name == null ? "${var.project_id}-push-based-log-export-role" : var.iam_role_name
+  random_suffix            = random_string.this.result
+  bucket_name_def          = var.bucket_name == null ? "${var.project_id}-atlas-push-log-${local.random_suffix}" : var.bucket_name
+  iam_role_name_def        = var.iam_role_name == null ? "${var.project_id}-push-based-log-export-role-${local.random_suffix}" : var.iam_role_name
   iam_role_policy_name_def = var.iam_role_policy_name == null ? "${var.project_id}-push-based-log-export-policy" : var.iam_role_policy_name
 }
 

--- a/modules/s3_bucket/variables.tf
+++ b/modules/s3_bucket/variables.tf
@@ -4,7 +4,7 @@ variable "project_id" {
 }
 
 variable "bucket_name" {
-  description = "Name of the bucket that Atlas will sends the logs to. If you provide no value, a default value of the form {project_id}-atlas-push-log-{timestamp} is assigned (e.g., 66a7ae173df3c34412a71cd6-atlas-push-log-24-7-29-15-0-38)."
+  description = "Name of the bucket that Atlas will sends the logs to. If you provide no value, a default value of the form {project_id}-atlas-push-log-{random_string} is assigned (e.g., 66a7ae173df3c34412a71cd6-atlas-push-log-asdfg)."
   type        = string
   default     = null
   nullable    = true
@@ -17,7 +17,7 @@ variable "create_bucket" {
 }
 
 variable "iam_role_name" {
-  description = "Name of the IAM role to use to set up cloud provider access in Atlas. If you provide no value, a default value of the form {project_id}-push-based-log-export-role is assigned (e.g., 66a7ae173df3c34412a71cd6-push-based-log-export-role)."
+  description = "Name of the IAM role to use to set up cloud provider access in Atlas. If you provide no value, a default value of the form {project_id}-push-based-log-export-role-{random_string} is assigned (e.g., 66a7ae173df3c34412a71cd6-push-based-log-export-role-asdfg)."
   type        = string
   default     = null
   nullable    = true


### PR DESCRIPTION
## Description

Replaced timestamp in bucket name by random string (also added random string as a suffix of the IAM role name). This is because, with the timestamp, at every re-execution of the same instance the bucket was replaced / re-created again.
